### PR TITLE
fix: set length of RecordMat::token with NAMEDATALEN

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub fn tokenize(t: &str) -> Vec<String> {
 #[derive(Debug)]
 #[repr(C)]
 struct RecordMat {
-    token: [u8; 64],
+    token: [u8; pgrx::pg_sys::NAMEDATALEN as usize],
     id: i32,
     how_many_tokens: i32,
     idf: f32,


### PR DESCRIPTION
The length of `NAME` type can be customized in `include/pg_config_manual.h` from postgre. It's better to use macro from postgres instead of hard coding.